### PR TITLE
Color Button and Font Button - Simple two-way binding

### DIFF
--- a/src/Controls/Controls.GTK/Renderers/ColorButtonRenderer.cs
+++ b/src/Controls/Controls.GTK/Renderers/ColorButtonRenderer.cs
@@ -77,7 +77,9 @@ namespace FormsGtkToolkit.Controls.GTK.Renderers
         private void OnColorSet(object sender, System.EventArgs e)
         {
             var selectedColor = Control.Color;
+            var gdkMaxVal = 65535;
 
+            Element.Color = new Color(selectedColor.Red / (double)gdkMaxVal, selectedColor.Green / (double)gdkMaxVal, selectedColor.Blue / (double)gdkMaxVal, 255);
             Element.SendColorChanged();
         }
     }

--- a/src/Controls/Controls.GTK/Renderers/FontButtonRenderer.cs
+++ b/src/Controls/Controls.GTK/Renderers/FontButtonRenderer.cs
@@ -107,6 +107,8 @@ namespace FormsGtkToolkit.Controls.GTK.Renderers
 
         private void OnFontSet(object sender, System.EventArgs e)
         {
+            Element.FontName = Control.FontName;
+
             Element.SendFontChanged();
         }
     }


### PR DESCRIPTION
### Description of Change

Color Button - ColorProperty now supports two-way binding.
Font Button - FontProperty now supports two-way binding.

### Example
[https://github.com/DlbSt/GTKWebsiteSamples/](https://github.com/DlbSt/GTKWebsiteSamples/) - You can find it in dialog page.

### Bugs Fixed

Fixes [#1](https://github.com/jsuarezruiz/FormsGtkToolkit/issues/1).